### PR TITLE
Genericize JSON service

### DIFF
--- a/Karma/Models/IHasJsonFIle.cs
+++ b/Karma/Models/IHasJsonFIle.cs
@@ -1,0 +1,7 @@
+namespace Karma.Models
+{
+    public interface IHasJsonFile
+    {
+        string GetJsonName();
+    }
+}

--- a/Karma/Models/IJsonStorable.cs
+++ b/Karma/Models/IJsonStorable.cs
@@ -1,6 +1,6 @@
 namespace Karma.Models
 {
-    public interface IHasJsonFile
+    public interface IJsonStorable
     {
         string GetJsonName();
     }

--- a/Karma/Models/PostModel.cs
+++ b/Karma/Models/PostModel.cs
@@ -1,0 +1,27 @@
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Text.Json.Serialization;
+using System.Text.Json;
+
+namespace Karma.Models
+{
+    public abstract class PostModel
+    {
+
+        public string PosterName { get; set; }
+
+        public string City { get; set; }
+
+        public string PhoneNumber { get; set; }
+
+        public string Title { get; set; }
+
+        public string Description { get; set; }
+
+        public abstract override string ToString();
+
+    }
+}

--- a/Karma/Models/RequestModel.cs
+++ b/Karma/Models/RequestModel.cs
@@ -7,7 +7,7 @@ using System.Text.Json;
 
 namespace Karma.Models
 {
-    public class RequestModel : PostModel, IHasJsonFile
+    public class RequestModel : PostModel, IJsonStorable
     {
         public override string ToString() => JsonSerializer.Serialize<RequestModel>(this);
 

--- a/Karma/Models/RequestModel.cs
+++ b/Karma/Models/RequestModel.cs
@@ -7,19 +7,10 @@ using System.Text.Json;
 
 namespace Karma.Models
 {
-    public class RequestModel
+    public class RequestModel : PostModel, IHasJsonFile
     {
-
-        public string RequesterName { get; set; }
-
-        public string City { get; set; }
-
-        public string PhoneNumber { get; set; }
-
-        public string Title { get; set; }
-
-        public string Description { get; set; }
-
         public override string ToString() => JsonSerializer.Serialize<RequestModel>(this);
+
+        public string GetJsonName() => "requests.json";
     }
 }

--- a/Karma/Models/SubmitModel.cs
+++ b/Karma/Models/SubmitModel.cs
@@ -4,20 +4,12 @@ using System.Text.Json.Serialization;
 
 namespace Karma.Models
 {
-    public class SubmitModel
+    public class SubmitModel : PostModel, IHasJsonFile
     {
-        public string SubmitterName { get; set; }
-
-        public string City { get; set; }
-
-        public string PhoneNumber { get; set; }
-
-        public string Title { get; set; }
-
-        public string Description { get; set; }
-
         public string Picture { get; set;}
         
         public override string ToString() => JsonSerializer.Serialize<SubmitModel>(this);
+        public string GetJsonName() => "items.json";
+
     }
 }

--- a/Karma/Models/SubmitModel.cs
+++ b/Karma/Models/SubmitModel.cs
@@ -4,7 +4,7 @@ using System.Text.Json.Serialization;
 
 namespace Karma.Models
 {
-    public class SubmitModel : PostModel, IHasJsonFile
+    public class SubmitModel : PostModel, IJsonStorable
     {
         public string Picture { get; set;}
         

--- a/Karma/Pages/RequestCatalog.cshtml.cs
+++ b/Karma/Pages/RequestCatalog.cshtml.cs
@@ -13,12 +13,12 @@ namespace Karma.Pages
     public class GetRequestsModel : PageModel
     {
         private readonly ILogger<RequestModel> _logger;
-        public JsonFileRequestService RequestService;   
+        public JsonFileRequestService<RequestModel> RequestService;   
         public IEnumerable<RequestModel> Requests { get; private set; }
 
         public GetRequestsModel(
             ILogger<RequestModel> logger,
-            JsonFileRequestService requestService)
+            JsonFileRequestService<RequestModel> requestService)
         {
             _logger = logger;
             RequestService = requestService;
@@ -26,7 +26,7 @@ namespace Karma.Pages
 
         public void OnGet()
         {
-            Requests = RequestService.GetRequests();
+            Requests = RequestService.GetPosts();
         }
     }
 }

--- a/Karma/Pages/RequestCatalog.cshtml.cs
+++ b/Karma/Pages/RequestCatalog.cshtml.cs
@@ -13,12 +13,12 @@ namespace Karma.Pages
     public class GetRequestsModel : PageModel
     {
         private readonly ILogger<RequestModel> _logger;
-        public JsonFileRequestService<RequestModel> RequestService;   
+        public JsonFilePostService<RequestModel> RequestService;   
         public IEnumerable<RequestModel> Requests { get; private set; }
 
         public GetRequestsModel(
             ILogger<RequestModel> logger,
-            JsonFileRequestService<RequestModel> requestService)
+            JsonFilePostService<RequestModel> requestService)
         {
             _logger = logger;
             RequestService = requestService;

--- a/Karma/Pages/Requests.cshtml
+++ b/Karma/Pages/Requests.cshtml
@@ -20,7 +20,7 @@
         </div>
         <div class="mb-3">
             <label class="form-label">Your name</label>
-            <input type="text" class="form-control" asp-for="Item.RequesterName">
+            <input type="text" class="form-control" asp-for="Item.PosterName">
         </div>
         <div class="mb-3">
             <label class="form-label">City</label>

--- a/Karma/Pages/Requests.cshtml.cs
+++ b/Karma/Pages/Requests.cshtml.cs
@@ -14,10 +14,10 @@ namespace Karma.Pages
         [BindProperty]
         public RequestModel Item { get; set; }
 
-        public JsonFileRequestService<RequestModel> RequestService;   
+        public JsonFilePostService<RequestModel> RequestService;   
         public IEnumerable<RequestModel> Requests { get; private set; }
 
-        public RequestsModel(JsonFileRequestService<RequestModel> requestService)
+        public RequestsModel(JsonFilePostService<RequestModel> requestService)
         {
             RequestService = requestService;
         }
@@ -31,11 +31,9 @@ namespace Karma.Pages
             {
                 return Page();
             }
-            List<RequestModel> newRequest = new List<RequestModel>();
-            newRequest.Add(Item);
 
             Requests = RequestService.GetPosts().
-            Concat<RequestModel>(newRequest);
+            Append<RequestModel>(Item);
 
             RequestService.RefreshPosts(Requests);
 

--- a/Karma/Pages/Requests.cshtml.cs
+++ b/Karma/Pages/Requests.cshtml.cs
@@ -14,10 +14,10 @@ namespace Karma.Pages
         [BindProperty]
         public RequestModel Item { get; set; }
 
-        public JsonFileRequestService RequestService;   
+        public JsonFileRequestService<RequestModel> RequestService;   
         public IEnumerable<RequestModel> Requests { get; private set; }
 
-        public RequestsModel(JsonFileRequestService requestService)
+        public RequestsModel(JsonFileRequestService<RequestModel> requestService)
         {
             RequestService = requestService;
         }
@@ -34,10 +34,10 @@ namespace Karma.Pages
             List<RequestModel> newRequest = new List<RequestModel>();
             newRequest.Add(Item);
 
-            Requests = RequestService.GetRequests().
+            Requests = RequestService.GetPosts().
             Concat<RequestModel>(newRequest);
 
-            RequestService.RefreshRequests(Requests);
+            RequestService.RefreshPosts(Requests);
 
             return RedirectToPage("/Index");
         }

--- a/Karma/Pages/Submits.cshtml
+++ b/Karma/Pages/Submits.cshtml
@@ -21,7 +21,7 @@
         </div>
         <div class="mb-3">
             <label class="form-label">Your name</label>
-            <input type="text" class="form-control" asp-for="Item.SubmitterName">
+            <input type="text" class="form-control" asp-for="Item.PosterName">
         </div>
         <div class="mb-3">
             <label class="form-label">City</label>

--- a/Karma/Pages/Submits.cshtml
+++ b/Karma/Pages/Submits.cshtml
@@ -32,8 +32,8 @@
             <input type="text" class="form-control" asp-for="Item.PhoneNumber">
         </div>
         <div class="mb-3">
-            <label for="formFile" class="form-label">Picture</label>
-            <input class="form-control" type="file" asp-for="Item.Picture">
+            <label class="form-label">Picture</label>
+            <input type="text" class="form-control" asp-for="Item.Picture">
         </div>
 
         <button type="submit" class="btn btn-primary">Submit</button>

--- a/Karma/Pages/Submits.cshtml.cs
+++ b/Karma/Pages/Submits.cshtml.cs
@@ -5,12 +5,22 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Karma.Models;
+using Karma.Services;
+
 namespace Karma.Pages
 {
     public class SubmitsModel : PageModel
     {
         [BindProperty]
         public SubmitModel Item { get; set; }
+
+        public JsonFilePostService<SubmitModel> SubmitService;
+        public IEnumerable<SubmitModel> Submits { get; private set; }
+
+        public SubmitsModel(JsonFilePostService<SubmitModel> submitService)
+        {
+            SubmitService = submitService;
+        }
         public void OnGet()
         {
         }
@@ -22,6 +32,11 @@ namespace Karma.Pages
             {
                 return Page();
             }
+
+            Submits = SubmitService.GetPosts().
+            Append<SubmitModel>(Item);
+
+            SubmitService.RefreshPosts(Submits);
 
             return RedirectToPage("/Index");
         }

--- a/Karma/Services/JsonFilePostService.cs
+++ b/Karma/Services/JsonFilePostService.cs
@@ -8,27 +8,23 @@ using System.Threading.Tasks;
 
 namespace Karma.Services
 {
-    public class JsonFileRequestService<T> where T : PostModel, IHasJsonFile
+    public class JsonFilePostService<T> where T : IHasJsonFile, new()
     {
-        public JsonFileRequestService(IWebHostEnvironment webHostEnvironment)
+        public JsonFilePostService(IWebHostEnvironment webHostEnvironment)
         {
             WebHostEnvironment = webHostEnvironment;
         }
 
         public IWebHostEnvironment WebHostEnvironment { get; }
 
-        private string JsonFileName(System.Type type)
+        private string JsonFileName
         {
-            if(type == typeof(RequestModel))
-                return Path.Combine(WebHostEnvironment.ContentRootPath, "data", (new RequestModel()).GetJsonName()); 
-            if(type == typeof(SubmitModel))
-                return Path.Combine(WebHostEnvironment.ContentRootPath, "data", (new SubmitModel()).GetJsonName()); 
-            return "";  
+                get { return Path.Combine(WebHostEnvironment.ContentRootPath, "data", (new T()).GetJsonName()); }
         }
 
         public IEnumerable<T> GetPosts()
         {
-            using(var jsonFileReader = File.OpenText(JsonFileName(typeof(T))))
+            using(var jsonFileReader = File.OpenText(JsonFileName))
             {
                 return JsonSerializer.Deserialize<T[]>(jsonFileReader.ReadToEnd(),
                     new JsonSerializerOptions
@@ -41,7 +37,7 @@ namespace Karma.Services
         public void RefreshPosts(IEnumerable<T> requests)
         {
             File.WriteAllTextAsync(
-                JsonFileName(typeof(T)), 
+                JsonFileName, 
                 JsonSerializer.Serialize<IEnumerable<T>>(requests, 
                 new JsonSerializerOptions {WriteIndented = true}));
         }

--- a/Karma/Services/JsonFilePostService.cs
+++ b/Karma/Services/JsonFilePostService.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace Karma.Services
 {
-    public class JsonFilePostService<T> where T : IHasJsonFile, new()
+    public class JsonFilePostService<T> where T : IJsonStorable, new()
     {
         public JsonFilePostService(IWebHostEnvironment webHostEnvironment)
         {

--- a/Karma/Services/JsonFileRequestService.cs
+++ b/Karma/Services/JsonFileRequestService.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace Karma.Services
 {
-    public class JsonFileRequestService
+    public class JsonFileRequestService<T> where T : PostModel, IHasJsonFile
     {
         public JsonFileRequestService(IWebHostEnvironment webHostEnvironment)
         {
@@ -17,16 +17,20 @@ namespace Karma.Services
 
         public IWebHostEnvironment WebHostEnvironment { get; }
 
-        private string JsonFileName
+        private string JsonFileName(System.Type type)
         {
-            get { return Path.Combine(WebHostEnvironment.ContentRootPath, "data", "requests.json"); }
+            if(type == typeof(RequestModel))
+                return Path.Combine(WebHostEnvironment.ContentRootPath, "data", (new RequestModel()).GetJsonName()); 
+            if(type == typeof(SubmitModel))
+                return Path.Combine(WebHostEnvironment.ContentRootPath, "data", (new SubmitModel()).GetJsonName()); 
+            return "";  
         }
 
-        public IEnumerable<RequestModel> GetRequests()
+        public IEnumerable<T> GetPosts()
         {
-            using(var jsonFileReader = File.OpenText(JsonFileName))
+            using(var jsonFileReader = File.OpenText(JsonFileName(typeof(T))))
             {
-                return JsonSerializer.Deserialize<RequestModel[]>(jsonFileReader.ReadToEnd(),
+                return JsonSerializer.Deserialize<T[]>(jsonFileReader.ReadToEnd(),
                     new JsonSerializerOptions
                     {
                         PropertyNameCaseInsensitive = true
@@ -34,11 +38,11 @@ namespace Karma.Services
             }
         }
 
-        public void RefreshRequests(IEnumerable<RequestModel> requests)
+        public void RefreshPosts(IEnumerable<T> requests)
         {
             File.WriteAllTextAsync(
-                JsonFileName, 
-                JsonSerializer.Serialize<IEnumerable<RequestModel>>(requests, 
+                JsonFileName(typeof(T)), 
+                JsonSerializer.Serialize<IEnumerable<T>>(requests, 
                 new JsonSerializerOptions {WriteIndented = true}));
         }
     }

--- a/Karma/Startup.cs
+++ b/Karma/Startup.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Karma.Services;
+using Karma.Models;
 
 namespace Karma
 {
@@ -25,7 +26,8 @@ namespace Karma
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddRazorPages();
-            services.AddTransient<JsonFileRequestService>();
+            services.AddTransient<JsonFileRequestService<RequestModel>>();
+            services.AddTransient<JsonFileRequestService<SubmitModel>>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/Karma/Startup.cs
+++ b/Karma/Startup.cs
@@ -26,8 +26,8 @@ namespace Karma
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddRazorPages();
-            services.AddTransient<JsonFileRequestService<RequestModel>>();
-            services.AddTransient<JsonFileRequestService<SubmitModel>>();
+            services.AddTransient<JsonFilePostService<RequestModel>>();
+            services.AddTransient<JsonFilePostService<SubmitModel>>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/Karma/data/items.json
+++ b/Karma/data/items.json
@@ -1,5 +1,5 @@
 {
-  "SubmitterName": "Edvin",
+  "PosterName": "Edvin",
   "City": "Vilnius",
   "PhoneNumber": "+370696969",
   "Title": "title",

--- a/Karma/data/items.json
+++ b/Karma/data/items.json
@@ -1,8 +1,10 @@
-{
-  "PosterName": "Edvin",
-  "City": "Vilnius",
-  "PhoneNumber": "+370696969",
-  "Title": "title",
-  "Description": "desc",
-  "Picture": "link"
-}
+[
+  {
+    "PosterName": "Edvin",
+    "City": "Vilnius",
+    "PhoneNumber": "+370696969",
+    "Title": "title",
+    "Description": "desc",
+    "Picture": "link"
+  }
+]

--- a/Karma/data/requests.json
+++ b/Karma/data/requests.json
@@ -1,16 +1,23 @@
 [
   {
-    "RequesterName": null,
+    "PosterName": null,
     "City": "Marijampole",
     "PhoneNumber": "\u002B370696969",
     "Title": "title",
     "Description": "desc"
   },
   {
-    "RequesterName": "Dee Snutz",
-    "City": "Vilnius",
-    "PhoneNumber": "\u002B66468419",
-    "Title": "green",
-    "Description": "black"
+    "PosterName": "asdasd",
+    "City": "asdsa",
+    "PhoneNumber": "adsad",
+    "Title": "asda",
+    "Description": "asda"
+  },
+  {
+    "PosterName": "adasd",
+    "City": null,
+    "PhoneNumber": null,
+    "Title": "asdas",
+    "Description": "asdad"
   }
 ]


### PR DESCRIPTION
Main changes: 
1. JSON service class was made generic, so it can be configured for any class that implements IJsonStorable.cs interface. The interface makes sure the class should have a JSON file where objects of the same class are stored.
2. Applied our new service class to rest of the application.

Optional changes: 

1. I added an abstract super class PostModel.cs, since the only difference between SubmitModel and RequestModel is that SubmitModel has picture property. I am still not sure if we will need this class, though this class can be used for adding constraint to our JSON service class, so that the service can be applied to classes that derive from PostModel.
2. Things mentioned above also affected names of properties, because there is no need for different property names for our classes, since they now are connected by PostModel super class.