### PR TITLE
Add image upload, display features, and generic page for Items

### DIFF
--- a/Karma/Pages/Item.cshtml
+++ b/Karma/Pages/Item.cshtml
@@ -6,5 +6,5 @@
 <h1>@ViewData["Title"]</h1>
 
 <p>@Model.Item.Title</p>
-<!-- <img src= "@Model.Item.Picture" asp-append-version=true>-->
+<img src= "/images/@Model.Item.Picture" asp-append-version=true>
 

--- a/Karma/Pages/Item.cshtml
+++ b/Karma/Pages/Item.cshtml
@@ -1,0 +1,10 @@
+@page
+@model ItemModel
+@{
+    ViewData["Title"] = "Item";
+}
+<h1>@ViewData["Title"]</h1>
+
+<p>@Model.Item.Title</p>
+<!-- <img src= "@Model.Item.Picture" asp-append-version=true>-->
+

--- a/Karma/Pages/Item.cshtml.cs
+++ b/Karma/Pages/Item.cshtml.cs
@@ -1,0 +1,40 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Karma.Models;
+using System.Text.Json;
+using Microsoft.AspNetCore.Hosting;
+using System.IO;
+
+namespace Karma.Pages
+{
+    public class ItemModel : PageModel
+    {
+        private readonly ILogger<ItemModel> _logger;
+        private IWebHostEnvironment WebHostEnvironment { get; }
+
+        public SubmitModel Item { get; set; }
+
+        [BindProperty(SupportsGet = true)]
+        public string itemJson { get; set; }
+
+        public ItemModel(
+            ILogger<ItemModel> logger,
+            IWebHostEnvironment webHostEnvironment)
+        {
+            _logger = logger;
+            WebHostEnvironment = webHostEnvironment;
+        }
+
+        public void OnGet()
+        {
+            SubmitModel deserializedItem = JsonSerializer.Deserialize<SubmitModel>(itemJson);
+            Item = deserializedItem;
+        }
+    }
+}
+

--- a/Karma/Pages/Submits.cshtml
+++ b/Karma/Pages/Submits.cshtml
@@ -6,7 +6,9 @@
 
 <h1>@ViewData["Title"]</h1>
 
-<form method="post">
+<!--do some research about this enctype thingie-->
+
+<form method="post" enctype="multipart/form-data">
 
     <button type="button" class="btn btn-primary mt-3" data-toggle="collapse" data-target="#demo">Submit an item</button>
     <div id="demo" class="collapse">
@@ -33,7 +35,7 @@
         </div>
         <div class="mb-3">
             <label class="form-label">Picture</label>
-            <input type="text" class="form-control" asp-for="Item.Picture">
+            <input class="form-control" type="file" asp-for="Photo">
         </div>
 
         <button type="submit" class="btn btn-primary">Submit</button>

--- a/Karma/Pages/Submits.cshtml
+++ b/Karma/Pages/Submits.cshtml
@@ -48,7 +48,8 @@
     @{
         for (int i = Model.Submits.Count() - 1; i >= 0; i--)
         {
-            <a href="#" class="list-group-item list-group-item-action">
+            
+            <a asp-page="/Item" asp-route-itemJson=@Model.Submits.ElementAt(i) class="list-group-item list-group-item-action">
                 <div class="d-flex w-100 justify-content-between">
                     <h5 class="mb-1">@Model.Submits.ElementAt(i).Title</h5>
                     <small>@Model.Submits.ElementAt(i).PosterName</small>

--- a/Karma/Pages/Submits.cshtml.cs
+++ b/Karma/Pages/Submits.cshtml.cs
@@ -25,8 +25,9 @@ namespace Karma.Pages
         private IWebHostEnvironment WebHostEnvironment { get; }
         public IEnumerable<SubmitModel> Submits { get; private set; }
 
-        public SubmitsModel(JsonFilePostService<SubmitModel> submitService,
-                            IWebHostEnvironment webHostEnvironment)
+        public SubmitsModel(
+            JsonFilePostService<SubmitModel> submitService,
+            IWebHostEnvironment webHostEnvironment)
         {
             SubmitService = submitService;
             WebHostEnvironment = webHostEnvironment;    


### PR DESCRIPTION
1. Now you can upload (and change) item pictures. 
2. I also added a generic item Razor Page that will be displayed on item click in Submit Page. The item JSON message string will be parsed along with the redirection, so the Item page will have all of the information about the item. The message can be de serialized and interacted through that items' object.