### PR TITLE
Add another GET request to access email outgoing messages

### DIFF
--- a/Karma/Areas/Identity/Pages/Account/Manage/Inbox.cshtml.cs
+++ b/Karma/Areas/Identity/Pages/Account/Manage/Inbox.cshtml.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Json;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Karma.Models;
 using Karma.Services;
@@ -25,12 +26,14 @@ namespace Karma.Areas.Identity.Pages.Account
         public async Task<IActionResult> OnGetAsync()
         {
             var email = User.Identity.Name;
-            var options = new JsonSerializerOptions();
-            options.PropertyNameCaseInsensitive = true;
-            options.ReferenceHandler = System.Text.Json.Serialization.ReferenceHandler.Preserve;
-            var jsonString = await HttpClient.GetStringAsync($"https://localhost:5001/api/messages/{email}");
-            Inbox = JsonSerializer.Deserialize<List<Message>>(jsonString, options);
-            //Inbox = JsonSerializer.Deserialize<List<Message>>("[{\"MessageId\":4,\"FromEmail\":\"d@gmail.com\", \"ToEmail\":\"ayy@gmail\", \"Content\":\"Text\"}]");
+
+            Inbox = await HttpClient.GetFromJsonAsync<List<Message>>($"https://localhost:5001/api/messages/to/{email}",
+                new JsonSerializerOptions()
+                {
+                    PropertyNameCaseInsensitive = true,
+                    ReferenceHandler = ReferenceHandler.Preserve
+                });
+
             return Page();
         }
     }

--- a/Karma/Areas/Identity/Pages/Account/Manage/Outbox.cshtml
+++ b/Karma/Areas/Identity/Pages/Account/Manage/Outbox.cshtml
@@ -10,7 +10,7 @@
     {
         <div class="card mt-2">
             <div class="card-header">
-                <p class="m-0">From @message.FromEmail</p>
+                <p class="m-0">To @message.ToEmail</p>
             </div>
             <div class="card-body">
                 @message.Content

--- a/Karma/Areas/Identity/Pages/Account/Manage/Outbox.cshtml.cs
+++ b/Karma/Areas/Identity/Pages/Account/Manage/Outbox.cshtml.cs
@@ -1,6 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Karma.Models;
 using Karma.Services;
@@ -12,20 +16,25 @@ namespace Karma.Areas.Identity.Pages.Account
     public class OutboxModel : PageModel
     {
 
-        public OutboxModel(IMessageRepository messageService)
+        public OutboxModel(HttpClient httpClient)
         {
-            MessageService = messageService;
+            HttpClient = httpClient;
         }
 
         public List<Message> Outbox { get; set; }
-        public IMessageRepository MessageService { get; }
+        public HttpClient HttpClient { get; }
 
         public async Task<IActionResult> OnGetAsync()
         {
-            Outbox = (await MessageService.GetMessages()).Where(delegate (Message m)
-            {
-                return m.FromEmail == HttpContext.User.Identity.Name;
-            }).ToList();
+            var email = User.Identity.Name;
+
+            Outbox = await HttpClient.GetFromJsonAsync<List<Message>>($"https://localhost:5001/api/messages/from/{email}",
+                new JsonSerializerOptions()
+                {
+                    PropertyNameCaseInsensitive = true,
+                    ReferenceHandler = ReferenceHandler.Preserve
+                });
+
             return Page();
         }
     }

--- a/Karma/Controllers/MessagesController.cs
+++ b/Karma/Controllers/MessagesController.cs
@@ -1,9 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Karma.Models;
 using Karma.Services;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
@@ -20,18 +23,40 @@ namespace Karma.Controllers
 
         public IMessageRepository MessageService { get; }
 
+        [Authorize]
         [HttpGet("to/{email}")]
         public async Task<ActionResult<Message>> GetMessagesTo(string email)
         {
-            var messages = await MessageService.GetMessagesToEmail(email);
-            return Ok(messages);
+            try
+            {
+                if (email != User.Identity.Name)
+                    return Unauthorized();
+
+                var messages = await MessageService.GetMessagesToEmail(email);
+                return Ok(messages);
+            }
+            catch (Exception)
+            {
+                return StatusCode(StatusCodes.Status500InternalServerError, "Error retrieving data from the database");
+            }
         }
 
+        [Authorize]
         [HttpGet("from/{email}")]
         public async Task<ActionResult<Message>> GetMessagesFrom(string email)
         {
-            var messages = await MessageService.GetMessagesFromEmail(email);
-            return Ok(messages);
+            try
+            {
+                if (email != User.Identity.Name)
+                    return Unauthorized();
+
+                var messages = await MessageService.GetMessagesFromEmail(email);
+                return Ok(messages);
+            }
+            catch (Exception)
+            {
+                return StatusCode(StatusCodes.Status500InternalServerError, "Error retrieving data from the database");
+            }
         }
     }
 }

--- a/Karma/Controllers/MessagesController.cs
+++ b/Karma/Controllers/MessagesController.cs
@@ -20,10 +20,17 @@ namespace Karma.Controllers
 
         public IMessageRepository MessageService { get; }
 
-        [HttpGet("{email}")]
-        public async Task<ActionResult<Message>> Get(string email)
+        [HttpGet("to/{email}")]
+        public async Task<ActionResult<Message>> GetMessagesTo(string email)
         {
-            var messages = await MessageService.GetMessagesByEmail(email);
+            var messages = await MessageService.GetMessagesToEmail(email);
+            return Ok(messages);
+        }
+
+        [HttpGet("from/{email}")]
+        public async Task<ActionResult<Message>> GetMessagesFrom(string email)
+        {
+            var messages = await MessageService.GetMessagesFromEmail(email);
             return Ok(messages);
         }
     }

--- a/Karma/Services/IMessageRepository.cs
+++ b/Karma/Services/IMessageRepository.cs
@@ -10,6 +10,7 @@ namespace Karma.Services
     {
         public Task<List<Message>> GetMessages();
         public Task<Message> AddMessage(Message message);
-        public Task<List<Message>> GetMessagesByEmail(string email);
+        public Task<List<Message>> GetMessagesToEmail(string email);
+        public Task<List<Message>> GetMessagesFromEmail(string email);
     }
 }

--- a/Karma/Services/SQLMessageRepository.cs
+++ b/Karma/Services/SQLMessageRepository.cs
@@ -30,9 +30,13 @@ namespace Karma.Services
             return await Context.Messages.ToListAsync();
         }
 
-        public async Task<List<Message>> GetMessagesByEmail(string email)
+        public async Task<List<Message>> GetMessagesToEmail(string email)
         {
             return await Context.Messages.Where(m => m.ToEmail == email).ToListAsync();
+        }
+        public async Task<List<Message>> GetMessagesFromEmail(string email)
+        {
+            return await Context.Messages.Where(m => m.FromEmail == email).ToListAsync();
         }
     }
 }


### PR DESCRIPTION
A small change - now there are two GET requests understood by our MessagesController:
- /api/messages/in/{email}
- /api/messages/out/{email}