### PR TITLE
Generate hosing address automatically

### DIFF
--- a/Karma/Pages/Item.cshtml.cs
+++ b/Karma/Pages/Item.cshtml.cs
@@ -21,7 +21,7 @@ namespace Karma.Pages
 {
     public class ItemModel : PageModel
     {
-        private const string baseAddress = "https://localhost:5001/api/";
+        private string baseAddress = KarmaHttpContext.AppBaseUrl + "/api/";
 
         public HttpClient HttpClient { get; } = new HttpClient();
         [BindProperty]

--- a/Karma/Services/KarmaHttpContext.cs
+++ b/Karma/Services/KarmaHttpContext.cs
@@ -24,10 +24,6 @@ namespace Karma.Services
 
     public static class HttpContextExtensions
     {
-        public static void AddHttpContextAccessor(this IServiceCollection services)
-        {
-            services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
-        }
 
         public static IApplicationBuilder UseHttpContext(this IApplicationBuilder app)
         {

--- a/Karma/Services/KarmaHttpContext.cs
+++ b/Karma/Services/KarmaHttpContext.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Karma.Services
+{
+    public class KarmaHttpContext
+    {
+        private static IHttpContextAccessor m_httpContextAccessor;
+
+        public static HttpContext Current => m_httpContextAccessor.HttpContext;
+
+        public static string AppBaseUrl => $"{Current.Request.Scheme}://{Current.Request.Host}{Current.Request.PathBase}";
+
+        internal static void Configure(IHttpContextAccessor contextAccessor)
+        {
+            m_httpContextAccessor = contextAccessor;
+        }
+    }
+
+    public static class HttpContextExtensions
+    {
+        public static void AddHttpContextAccessor(this IServiceCollection services)
+        {
+            services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
+        }
+
+        public static IApplicationBuilder UseHttpContext(this IApplicationBuilder app)
+        {
+            KarmaHttpContext.Configure(app.ApplicationServices.GetRequiredService<IHttpContextAccessor>());
+            return app;
+        }
+    }
+}

--- a/Karma/Startup.cs
+++ b/Karma/Startup.cs
@@ -65,6 +65,7 @@ namespace Karma
             app.UseStaticFiles();
 
             app.UseRouting();
+            app.UseHttpContext();
 
             app.UseAuthentication();
             app.UseAuthorization();


### PR DESCRIPTION
I found a way of generating base URL, which will be used when sending HTTP requests. (karma.com/api/items)

Before this change, I basically resorted to hard coded localhost:5001 URL when issuing requests to our API. Which basically won't work, if this site gets deployed. 

This also slightly touches the middleware requirement, but I think it is still far from enough. app.UseHttpContext basically gives HTTP context to the HTTP request/response pipeline, which transitively gives us access to needed information to form a hosting URL.

I believe the is no simpler of doing this in ASP.NET.

References: [https://stackoverflow.com/questions/43526630/how-can-i-get-the-baseurl-of-my-site-in-asp-net-core]( https://stackoverflow.com/questions/43526630/how-can-i-get-the-baseurl-of-my-site-in-asp-net-core)